### PR TITLE
Python 3.7 and 3.8 support

### DIFF
--- a/cg_manage_rds/cmds/cf_cmds.py
+++ b/cg_manage_rds/cmds/cf_cmds.py
@@ -5,7 +5,7 @@ import signal
 import click
 import json
 import re
-import importlib.resources as ir
+from pathlib import PurePath
 import cg_manage_rds
 from cg_manage_rds.cmds.utils import run_sync, run_async
 
@@ -13,7 +13,7 @@ from cg_manage_rds.cmds.utils import run_sync, run_async
 def push_app(app_name: str, manifest: str = "manifest.yml") -> None:
     click.echo("Pushing App to space")
     orig_wd=getattr(sys, "_MEIPASS", os.getcwd())
-    app_dir = ir.files(cg_manage_rds).joinpath("cf-app").as_posix()
+    app_dir = PurePath(cg_manage_rds.__file__).parent.joinpath("cf-app").as_posix()
     #app_dir = os.path.join(base_path, "cf-app")
     os.chdir(app_dir)
     cmd = ["cf", "push", app_name, "-f", manifest]

--- a/cg_manage_rds/cmds/utils.py
+++ b/cg_manage_rds/cmds/utils.py
@@ -1,4 +1,5 @@
 
+from __future__ import annotations
 import subprocess
 import itertools
 import sys


### PR DESCRIPTION
## Changes proposed in this pull request:

- Minor updates for compatibility with Python 3.8 (tested) and likely Python 3.7

## Security considerations

N/A

cg-manage-rds contains some Python syntax & library usage that assumes Python 3.9. Currently Python 3.7 is the oldest actively-supported Python, and Python 3.8 is the version available for macOS via Xcode developer tools (so it should be the most commonly-found python3 version on macOS).

It might also be worth documenting the minimum Python version required to install via pip (Python 3.6 can still be found on supported Linux distros like Ubuntu 18.04 & RHEL / CentOS 7).