### PR TITLE
Update build-release.yml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -92,6 +92,16 @@ jobs:
             repository: cloud-gov/homebrew-cloudgov
             path: homebrew
             token: ${{secrets.CGCIBOT_PAT}}
+            persist-credentials: false
+        - name: Import bot's GPG key for signing commits
+          id: import-gpg
+          uses: crazy-max/ghaction-import-gpg@v4
+          with:
+            gpg_private_key: ${{ secrets.CGCIBOT_GPG_PRIVATE_KEY }}
+            passphrase: ${{ secrets.CGCIBOT_GPG_PASSPHRASE }}
+            git_config_global: true
+            git_user_signingkey: true
+            git_commit_gpgsign: true
         - name: update versions
           run: mv cg-manage-rds.env homebrew/Versions/cg-manage-rds/cg-manage-rds.env
         - name: GitHub Commit & Push
@@ -100,4 +110,8 @@ jobs:
             repository: cloud-gov/homebrew-cloudgov
             directory: homebrew
             github_token: ${{secrets.CGCIBOT_PAT}}
-
+          env:
+            GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+            GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+            GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+            GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}


### PR DESCRIPTION
adding gpg signing for cg-ci-bot user

## Changes proposed in this pull request:

- 
- 
- 

## Security considerations
cg-ci-bot private key is stored as an encrypted secret in this repo. Should not be a vulnerability, but should be noted. 
