### PR TITLE
Building ssh-app with fs4 linux stack

### DIFF
--- a/cg_manage_rds/cf-app/manifest.yml
+++ b/cg_manage_rds/cf-app/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: ssh-app
     buildpack: python_buildpack
-    stack: cflinuxfs3
+    stack: cflinuxfs4
     command: (echo SUCCESS || echo FAIL) && sleep infinity
     no-route: true
     health-check-type: none


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the linux stack for the ssh-app built to cflinuxfs4

## Error Message 
`Error: For application 'ssh-app': Buildpack "python_buildpack" for stack "cflinuxfs3" must be an existing admin buildpack or a valid git URI
`
## Security considerations
- Cloud.gov is rolling off of cflinuxfs4. (Reference Link: https://cloud.gov/2023/04/27/cflinuxfs3-deprecation-update/)

## Notes
- Needed this for the SRT app to dump a postgres db, and once I updated it to 4 it worked like a charm. 