### PR TITLE
fix workflow to include windows artifact in release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -80,6 +80,7 @@ jobs:
     needs:
     - build-linux
     - build-mac
+    - build-windows
     runs-on: ubuntu-latest
     steps:
     - name: Get Artifacts


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix workflow to include windows artifact in release

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Fixing workflow to include zip file for Windows executable of tool in the release
