### PR TITLE
Document Homebrew formula dependency & apply black formatting

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -90,6 +90,7 @@ jobs:
     - name: Make Release
       uses: softprops/action-gh-release@v1
       with:
+        generate_release_notes: true
         files: |
           dist/linux/cg-manage-rds.ubuntu-latest.x64.zip
           dist/macos/cg-manage-rds.macos-latest.x64.zip

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,41 @@
+# Developing cg-manage-rds
+
+## Setting up a local development environment
+
+```shell
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+## Formatting project code using `black`
+
+Make sure you have the virtual environment activated and then run:
+
+```shell
+black .
+```
+
+## Creating a new release
+
+1. Create a new tag:
+
+  ```shel
+  git tag -a v0.x.x -m "Version 0.x.x"
+  ```
+
+1. Push the tag
+
+  ```shell
+  git push origin v0.x.x
+  ```
+
+1. Once a new tag is pushed, the [GitHub Actions workflow](./.github/workflows/build-release.yml) will run to:
+
+    - Build an installable version of the package for:
+      - Mac
+      - Linux
+      - Windows
+    - Create a GitHub release for the tag
+    - Update the [Homebrew formula for `cg-manage-rds` in the `cloud-gov/cloudgov` tap](https://github.com/cloud-gov/homebrew-cloudgov)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,7 +21,7 @@ black .
 
 1. Create a new tag:
 
-  ```shel
+  ```shell
   git tag -a v0.x.x -m "Version 0.x.x"
   ```
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -37,5 +37,5 @@ black .
       - Mac
       - Linux
       - Windows
-    - Create a GitHub release for the tag
+    - Create a [GitHub release](https://github.com/cloud-gov/cg-manage-rds/releases) for the tag
     - Update the [Homebrew formula for `cg-manage-rds` in the `cloud-gov/cloudgov` tap](https://github.com/cloud-gov/homebrew-cloudgov)

--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@ There are three options for installation:
 brew install cloud-gov/cloudgov/cg-manage-rds
 ```
 
-2. Extract the bundled executable from the appropriate zipfile in the latest release:
+1. Extract the bundled executable from the appropriate zipfile in the latest release:
   
     <https://github.com/cloud-gov/cg-manage-rds/releases/latest>
 
-3. Use the python package manager [pip](https://pip.pypa.io/en/stable/) to install the latest directly from source in a local python environment.
+1. Use the python package manager [pip](https://pip.pypa.io/en/stable/) to install the latest directly from source in a local python environment.
 
 ```bash
 pip install git+https://github.com/cloud-gov/cg-manage-rds.git
 ```
+
+## Developing
+
+See [DEVELOPING.md](./DEVELOPING.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ pip install git+https://github.com/cloud-gov/cg-manage-rds.git
 
 See [DEVELOPING.md](./DEVELOPING.md).
 
+> **VERY IMPORTANT NOTE**: If you add a new package dependency in `requirements.txt`, you **must make a corresponding PR to [the template for the `cg-manage-rds` Homebrew formula](https://github.com/cloud-gov/homebrew-cloudgov/blob/main/Versions/cg-manage-rds/cg-manage-rds.tmpl) to explicitly add the new dependency**. For example, see <https://github.com/cloud-gov/homebrew-cloudgov/pull/3>.
+
 ## Usage
 
 The cg-manage-rds utility has multiple subcommands to provide specific functionality. Each of these will attempt to determine the type of database automatically from your service, but can be forced to use a specific type if needed. Under the hood the utility uses the `cf` , `ssh`, and the specific db engine utilities e.g. `psql` or `mysql` to do its work, so you must have those installed for your database. The commands:

--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ There are several utility commands to assist working with services:
 
 `Cleanup` will teardown the setup for a service.
 
+## Related projects
+
+- <https://github.com/cloud-gov/homebrew-cloudgov> - Contains Homebrew tap and formulas for cloud.gov, including [the templated formula for this package, `cg-manage-rds`](https://github.com/cloud-gov/homebrew-cloudgov/tree/main/Versions/cg-manage-rds)
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/cg_manage_rds/cli.py
+++ b/cg_manage_rds/cli.py
@@ -10,6 +10,7 @@ def main():
     Application to export, import, or clone a rds service instance from the aws-broker on Cloud.gov
     """
 
+
 ## CHECK
 @click.option(
     "-e",
@@ -44,7 +45,7 @@ def setup(service, key, app, engine):
     Setup app, key, and tunnel to a aws-rds service instance
 
     SERVICE name of the service instance
-    
+
     """
     click.echo(f"Setting up key, app and tunnel for {service}")
     creds, _ = commands.setup(service, engine, app, key)
@@ -76,7 +77,7 @@ def cleanup(
 
 
 ## Export
-@main.command("export",context_settings=CONTEXT_SETTINGS)
+@main.command("export", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-e",
     "--engine",
@@ -149,15 +150,15 @@ def export_db(
     cleanup,
 ):
     """
-        Export data and/or schema from SOURCE aws-rds service instance
+    Export data and/or schema from SOURCE aws-rds service instance
 
-        By default export will not preserve ownership,
-        and will attempt to create objects if they do not exist.
+    By default export will not preserve ownership,
+    and will attempt to create objects if they do not exist.
 
-        These defaults can be overridden with the --force-options flag.
+    These defaults can be overridden with the --force-options flag.
 
-        You can insert additional options and flags to the clients
-        using -o --options.
+    You can insert additional options and flags to the clients
+    using -o --options.
 
     """
     click.echo(f"Exporting {source} to file: {output_file}")
@@ -175,7 +176,7 @@ def export_db(
 
 
 ## Import
-@main.command("import",context_settings=CONTEXT_SETTINGS)
+@main.command("import", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-e",
     "--engine",
@@ -248,15 +249,15 @@ def import_db(
     cleanup,
 ):
     """
-        Import data and/or schema to DESTINATION rds service instance
+    Import data and/or schema to DESTINATION rds service instance
 
-        By default import will not preserve ownership,
-        and will attempt to create objects if they do not exist.
+    By default import will not preserve ownership,
+    and will attempt to create objects if they do not exist.
 
-        These defaults can be overridden with the --force-options flag.
+    These defaults can be overridden with the --force-options flag.
 
-        You can insert additional options and flags to the clients
-        using -o --options.
+    You can insert additional options and flags to the clients
+    using -o --options.
     """
     click.echo(f"Importing to {destination} from file: {input_file}")
     commands.import_to_svc(
@@ -337,15 +338,15 @@ def clone(
     app_name,
 ):
     """
-        Migrate data from one rds service to another rds service instance.
+    Migrate data from one rds service to another rds service instance.
 
-        By default export and import will not preserve ownership,
-        and will attempt to create objects if they do not exist.
+    By default export and import will not preserve ownership,
+    and will attempt to create objects if they do not exist.
 
-        These defaults can be overridden with the --force-options flag.
+    These defaults can be overridden with the --force-options flag.
 
-        You can insert additional options and flags to the clients
-        with either -b --boptions or -r --roptions.
+    You can insert additional options and flags to the clients
+    with either -b --boptions or -r --roptions.
 
     """
     click.echo(f"Cloning the database: {source} to {destination}")

--- a/cg_manage_rds/cmds/cf_cmds.py
+++ b/cg_manage_rds/cmds/cf_cmds.py
@@ -14,9 +14,10 @@ ALLOWED_CF_VERSIONS = [7, 8]
 CF_VERSION = 7
 CF_VERSION_PASSED = False
 
+
 def push_app(app_name: str, manifest: str = "manifest.yml") -> None:
     click.echo("Pushing App to space")
-    orig_wd=getattr(sys, "_MEIPASS", os.getcwd())
+    orig_wd = getattr(sys, "_MEIPASS", os.getcwd())
     app_dir = ir.files(cg_manage_rds).joinpath("cf-app").as_posix()
     os.chdir(app_dir)
     cmd = ["cf", "push", app_name, "-f", manifest]
@@ -118,34 +119,44 @@ def get_service_plan(service: str) -> str:
     click.echo("Retrieving Service Info...")
     cmd = ["cf", "service", service]
     code, result, status = run_sync(cmd)
-    planmatch = re.search("plan:.*\n",result)
+    planmatch = re.search("plan:.*\n", result)
     if code != 0 or planmatch is None:
         click.echo(status)
         raise click.ClickException(result)
     planline = planmatch.group()
     return planline.split()[-1]
 
+
 def check_cf_cli() -> None:
     global CF_VERSION_PASSED
     global CF_VERSION
-    if not CF_VERSION_PASSED :
+    if not CF_VERSION_PASSED:
         click.echo("Checking for CF version")
-        cmd = ["cf", "--version" ]
+        cmd = ["cf", "--version"]
         code, result, _ = run_sync(cmd)
         if code != 0:
             errstr = click.style(
-                "\ncf versions {} are supported, but none was found".format(ALLOWED_CF_VERSIONS), fg="red"
+                "\ncf versions {} are supported, but none was found".format(
+                    ALLOWED_CF_VERSIONS
+                ),
+                fg="red",
             )
             raise click.ClickException(errstr)
         [version, is_supported_cf_version] = validate_cf_cli_version(result)
         if not is_supported_cf_version:
             errstr = click.style(
-                "\ncf version {} does not match supported versions {} ".format(version, ALLOWED_CF_VERSIONS), fg="red"
+                "\ncf version {} does not match supported versions {} ".format(
+                    version, ALLOWED_CF_VERSIONS
+                ),
+                fg="red",
             )
             raise click.ClickException(errstr)
-        click.echo(click.style("\ncf version {} found!".format(version), fg="bright_green"))
-        CF_VERSION_PASSED=True
+        click.echo(
+            click.style("\ncf version {} found!".format(version), fg="bright_green")
+        )
+        CF_VERSION_PASSED = True
         CF_VERSION = version.major
+
 
 def validate_cf_cli_version(result: str) -> tuple[str, bool]:
     version = semver.Version.parse(result.split()[-1])

--- a/cg_manage_rds/cmds/engine.py
+++ b/cg_manage_rds/cmds/engine.py
@@ -4,15 +4,23 @@ from abc import ABC, abstractmethod
 class Engine(ABC):
     @abstractmethod
     def export_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str = None, ignore: bool = False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = None,
+        ignore: bool = False,
     ) -> None:
         pass
 
     @abstractmethod
     def import_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str = None, ignore: bool = False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = None,
+        ignore: bool = False,
     ) -> None:
         pass
 

--- a/cg_manage_rds/cmds/mysql.py
+++ b/cg_manage_rds/cmds/mysql.py
@@ -26,18 +26,21 @@ class MySql(Engine):
             raise click.ClickException(errstr)
         click.echo(click.style("\nmysqldump found!", fg="bright_green"))
 
-
     def export_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str="", ignore: bool=False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = "",
+        ignore: bool = False,
     ) -> None:
         click.echo(f"Exporting from MySql DB: {svc_name}")
-        opts=self.default_export_options(options,ignore)
+        opts = self.default_export_options(options, ignore)
         base_opts = self._creds_to_opts(creds)
         cmd = ["mysqldump"]
         cmd.extend(base_opts)
         cmd.extend(opts)
-        cmd.extend(["-r", backup_file, creds['db_name']])
+        cmd.extend(["-r", backup_file, creds["db_name"]])
         # mysqldump -u user -p"passwd" -h 127.0.0.1 -P 33306 -r backup_file -n --set-gtid-purged=OFF -f -y databasename
         click.echo("Exporting with:")
         click.echo(click.style("\t" + " ".join(cmd), fg="yellow"))
@@ -49,8 +52,12 @@ class MySql(Engine):
         click.echo("Export complete\n")
 
     def import_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str= "",  ignore: bool=False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = "",
+        ignore: bool = False,
     ) -> None:
         # mysql -u"user" -p"passwd" -h"127.0.0.1" -P"33306" -D"databasename" -e"source backup_file"
         click.echo(f"Importing to MySql DB: {svc_name}")
@@ -73,8 +80,10 @@ class MySql(Engine):
         cf.create_service_key(key_name, service_name)
         creds = cf.get_service_key(key_name, service_name)
         creds["local_port"] = int(creds.get("port")) + 30000
-        creds['local_host'] = '127.0.0.1'
-        creds['uri'] = f"mysql -u\"{creds['username']}\" -p\"{creds['password']}\" -h\"{creds['local_host']}\" -P\"{creds['local_port']}\" -D\"{creds['db_name']}\""
+        creds["local_host"] = "127.0.0.1"
+        creds["uri"] = (
+            f"mysql -u\"{creds['username']}\" -p\"{creds['password']}\" -h\"{creds['local_host']}\" -P\"{creds['local_port']}\" -D\"{creds['db_name']}\""
+        )
         return creds
 
     def default_export_options(self, options: str, ignore: bool = False) -> list:
@@ -85,13 +94,13 @@ class MySql(Engine):
         if ignore:
             return opts
         # dont create
-        if not any(x in [ "-n", "--no-create-db"] for x in opts):
+        if not any(x in ["-n", "--no-create-db"] for x in opts):
             opts.append("-n")
         # ignore tablespaces
-        if not any(x in [ "-y", "--tablespaces" ] for x in opts):
+        if not any(x in ["-y", "--tablespaces"] for x in opts):
             opts.append("-y")
         # push through errors
-        if not any(x in [ "-f", "--force" ] for x in opts):
+        if not any(x in ["-f", "--force"] for x in opts):
             opts.append("-f")
         if "--set-gtid-purged=OFF" not in opts:
             opts.append("--set-gtid-purged=OFF")
@@ -106,9 +115,9 @@ class MySql(Engine):
             opts = list()
         return opts
 
-    def _creds_to_opts(self,creds: dict) -> list:
+    def _creds_to_opts(self, creds: dict) -> list:
         opts = f"-u{creds['username']} "
-        opts+=f"-p{creds['password']} "
-        opts+=f"-P{creds['local_port']} "
-        opts+=f"-h{creds['local_host']} "
+        opts += f"-p{creds['password']} "
+        opts += f"-P{creds['local_port']} "
+        opts += f"-h{creds['local_host']} "
         return opts.split()

--- a/cg_manage_rds/cmds/pgsql.py
+++ b/cg_manage_rds/cmds/pgsql.py
@@ -13,9 +13,9 @@ class PgSql(Engine):
         cf.create_service_key(key_name, service_name)
         creds = cf.get_service_key(key_name, service_name)
         creds["local_port"] = int(creds.get("port")) + 60000
-        creds[
-            "uri"
-        ] = f"postgres://{creds['username']}:{creds['password']}@localhost:{creds['local_port']}/{creds['db_name']}"
+        creds["uri"] = (
+            f"postgres://{creds['username']}:{creds['password']}@localhost:{creds['local_port']}/{creds['db_name']}"
+        )
         return creds
 
     def prerequisites(self) -> None:
@@ -49,15 +49,19 @@ class PgSql(Engine):
         click.echo(click.style("\npg_restore found!", fg="bright_green"))
 
     def export_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str = None, ignore: bool = False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = None,
+        ignore: bool = False,
     ) -> None:
         click.echo(f"Exporting Postgres DB: {svc_name}")
         if options is not None:
             opts = options.split()
         else:
             opts = list()
-        opts = self.default_export_options(options,ignore)
+        opts = self.default_export_options(options, ignore)
         cmd = ["pg_dump", "-d", creds.get("uri"), "-f", backup_file]
         cmd.extend(opts)
         click.echo("Exporting up with:")
@@ -70,18 +74,22 @@ class PgSql(Engine):
         click.echo("Export complete\n")
 
     def import_svc(
-        self, svc_name: str, creds: dict, backup_file: str,
-        options: str = None, ignore: bool = False
+        self,
+        svc_name: str,
+        creds: dict,
+        backup_file: str,
+        options: str = None,
+        ignore: bool = False,
     ) -> None:
         click.echo(f"Importing to Postgres DB: {svc_name}")
         if options is not None:
             opts = options.split()
         else:
             opts = list()
-        if self._use_psql(backup_file): # sql file
+        if self._use_psql(backup_file):  # sql file
             cmd = ["psql", "-d", creds.get("uri"), "-f", backup_file]
             cmd.extend(opts)
-        else: # non sql format
+        else:  # non sql format
             cmd = ["pg_restore", "-d", creds.get("uri")]
             opts = self.default_import_options(options, ignore)
             cmd.extend(opts)
@@ -96,10 +104,10 @@ class PgSql(Engine):
         click.echo(status)
         click.echo("Import complete\n")
 
-    def default_export_options(self, options: str, ignore: bool = False) -> list: 
+    def default_export_options(self, options: str, ignore: bool = False) -> list:
         return self._default_options(options, ignore)
 
-    def default_import_options(self, options: str, ignore: bool = False) -> list: 
+    def default_import_options(self, options: str, ignore: bool = False) -> list:
         return self._default_options(options, ignore)
 
     def _default_options(self, options: str, ignore: bool = False) -> list:

--- a/cg_manage_rds/cmds/utils.py
+++ b/cg_manage_rds/cmds/utils.py
@@ -1,4 +1,3 @@
-
 import subprocess
 import itertools
 import sys

--- a/cg_manage_rds/commands.py
+++ b/cg_manage_rds/commands.py
@@ -6,14 +6,16 @@ from cg_manage_rds.cmds.engine import Engine
 from cg_manage_rds.cmds.pgsql import PgSql
 from cg_manage_rds.cmds.mysql import MySql
 
-def find_engine_type(service_name: str)->str:
+
+def find_engine_type(service_name: str) -> str:
     cf.check_cf_cli()
-    plan=cf.get_service_plan(service_name)
+    plan = cf.get_service_plan(service_name)
     if re.search("mysql", plan):
-        return 'mysql'
+        return "mysql"
     if re.search("psql", plan):
         return "pgsql"
     raise click.ClickException(f"Unsported service plan: {plan}")
+
 
 def get_engine_handler(engine_type: str) -> Engine:
     if engine_type == "pgsql":
@@ -24,18 +26,19 @@ def get_engine_handler(engine_type: str) -> Engine:
         raise click.ClickException(f"Unsupported Database Engine: {engine_type}")
 
 
-def check(service: str, engine_name: str=None) -> None:
+def check(service: str, engine_name: str = None) -> None:
     if engine_name is None:
         engine_name = find_engine_type(service)
     engine = get_engine_handler(engine_name)
     engine.prerequisites()
+
 
 def setup(
     service_name: str,
     engine_type: str = None,
     app_name: str = "ssh-app",
     key_name: str = "key",
-    engine: Engine= None,
+    engine: Engine = None,
 ) -> Tuple[dict, int]:
 
     if engine_type is None:
@@ -87,7 +90,9 @@ def export_from_svc(
     # either push app and create key, or reuse existing setup and key
     if do_setup:
         click.echo("Configuring CF space for SSH to Service")
-        creds, pid = setup(service_name, app_name=app_name, key_name=service_key, engine=engine)
+        creds, pid = setup(
+            service_name, app_name=app_name, key_name=service_key, engine=engine
+        )
         click.echo("Config complete\n")
     else:
         click.echo("Retrieving credentials for Service")
@@ -131,7 +136,9 @@ def import_to_svc(
     # either push app and create key, or reuse existing setup and key
     if do_setup:
         click.echo("Configuring CF space for SSH to Database")
-        creds, pid = setup(service_name, app_name=app_name, key_name=service_key, engine=engine)
+        creds, pid = setup(
+            service_name, app_name=app_name, key_name=service_key, engine=engine
+        )
         click.echo("Config complete\n")
     else:
         click.echo("Retrieving credentials for Database")
@@ -172,7 +179,9 @@ def clone(
 
     # First Backup source
     click.echo(f"Setting up CF space for SSH to {src_service}")
-    creds, pid = setup(src_service, app_name=app_name, key_name=service_key, engine=engine)
+    creds, pid = setup(
+        src_service, app_name=app_name, key_name=service_key, engine=engine
+    )
     click.echo("Setup complete\n")
 
     click.echo(f"Performing exprot of {src_service}")
@@ -185,7 +194,9 @@ def clone(
 
     # Now restore to destination
     click.echo(f"Setting up CF space for SSH to {dst_service}")
-    creds, pid = setup(dst_service, app_name=app_name, key_name=service_key, engine=engine)
+    creds, pid = setup(
+        dst_service, app_name=app_name, key_name=service_key, engine=engine
+    )
     click.echo("Setup complete\n")
 
     click.echo(f"Performing import to {dst_service}")

--- a/cg_manage_rds/tests/test_cf_cmds.py
+++ b/cg_manage_rds/tests/test_cf_cmds.py
@@ -1,15 +1,22 @@
 from cg_manage_rds.cmds import cf_cmds
 
+
 def test_validate_cf_cli_version():
-  # CF version 8 is supported
-  [version, is_valid] = cf_cmds.validate_cf_cli_version("cf version 8.5.0+73aa161.2022-09-12")
-  assert version.major == 8
-  assert(is_valid) is True
-  # CF version 7 is supported
-  [version, is_valid] = cf_cmds.validate_cf_cli_version("cf version 7.6.0+d1110f2.2023-02-27")
-  assert version.major == 7
-  assert(is_valid) is True
-  # CF version 9 is not supported
-  [version, is_valid] = cf_cmds.validate_cf_cli_version("cf version 9.6.0+d1110f2.2023-02-27")
-  assert version.major == 9
-  assert(is_valid) is False
+    # CF version 8 is supported
+    [version, is_valid] = cf_cmds.validate_cf_cli_version(
+        "cf version 8.5.0+73aa161.2022-09-12"
+    )
+    assert version.major == 8
+    assert (is_valid) is True
+    # CF version 7 is supported
+    [version, is_valid] = cf_cmds.validate_cf_cli_version(
+        "cf version 7.6.0+d1110f2.2023-02-27"
+    )
+    assert version.major == 7
+    assert (is_valid) is True
+    # CF version 9 is not supported
+    [version, is_valid] = cf_cmds.validate_cf_cli_version(
+        "cf version 9.6.0+d1110f2.2023-02-27"
+    )
+    assert version.major == 9
+    assert (is_valid) is False

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
-from setuptools import setup,find_packages
+from setuptools import setup, find_packages
 
 setup(
     name="cg-manage-rds",
     version="0.1.0",
     packages=find_packages("."),
     include_package_data=True,
-    package_data={
-        "cg_manage_rds": [
-            "cf-app/manifest.yml",
-            "cf-app/app.py"
-        ]
-    },
+    package_data={"cg_manage_rds": ["cf-app/manifest.yml", "cf-app/app.py"]},
     install_requires=[
         "Click",
     ],


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR includes documentation updates to highlight the related `cg-manage-rds` Homebrew formula and when/how to update it and code formatting updates using `black`

- [add developer documentation](https://github.com/cloud-gov/cg-manage-rds/commit/3bd9701ef1f914ef1bc2af01bce5287c49da8c98)
- [apply black formatting](https://github.com/cloud-gov/cg-manage-rds/commit/a7a5ae68444f9bc4e2f37d213e8d106adfe746a4)
- [update workflow to automatically generate release notes](https://github.com/cloud-gov/cg-manage-rds/commit/2d19911cd9c28dc6c759ea31f2aad5d56130e8c4)
- [add note about updating homebrew formula](https://github.com/cloud-gov/cg-manage-rds/commit/e8ee9678b15730e2764899800039b9f0e144072c)
- [update README](https://github.com/cloud-gov/cg-manage-rds/commit/4eb54442914fb738964652b841e6bb1783c28d0c)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just documentation/formatting updates
